### PR TITLE
2FA: Add env variable for altool App Specific Password.

### DIFF
--- a/lib/fastlane/plugin/validate_app/actions/validate_app_action.rb
+++ b/lib/fastlane/plugin/validate_app/actions/validate_app_action.rb
@@ -10,7 +10,7 @@ module Fastlane
         xcode_contents_path = `dirname "$(xcode-select --print-path)"`.strip
         altool = "#{xcode_contents_path}/Applications/Application Loader.app/Contents/Frameworks/ITunesSoftwareService.framework/Support/altool".shellescape
 
-        ENV["VALIDATE_APP_PASSWORD"] = ENV["FASTLANE_PASSWORD"] || ENV["DELIVER_PASSWORD"] || self.fetch_password_from_keychain
+        ENV["VALIDATE_APP_PASSWORD"] = ENV["ALTOOL_2FA_PASSWORD"] || ENV["FASTLANE_PASSWORD"] || ENV["DELIVER_PASSWORD"] || self.fetch_password_from_keychain
 
         ipa = params[:ipa].to_s.shellescape
         username = params[:username]


### PR DESCRIPTION
Use a new environment variable 'ALTOOL_2FA_PASSWORD' dedicated to the Application Specific Password for the Application Loader tool in order to support 2 Factor Authentication (2FA) without side effect on other fastlane actions.
Note that I gave the new variable priority over the default fastlane passwords ones.