### PR TITLE
2FA: Document new environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ fastlane add_plugin validate_app
 This plugin validates your ipa file using Application Loader's command line
 tool `altool`. By default, it will take your Apple ID username from your
 Appfile and password from yoru Keychain. You may specify a password directly or
-pass it via `FASTLANE_PASSWORD` or `DELIVER_PASSWORD` environment variables.
+pass it via `FASTLANE_PASSWORD` or `DELIVER_PASSWORD` environment variables. 
+If you use 2 factor authentication, you may specify the application specific 
+password for the Application Loader tool via `ALTOOL_2FA_PASSWORD`. This will 
+take precedence over your Apple ID's password. 
 Your password will not be printed out to build console log.
 
 Returns `nil` if build is valid, and an array of error objects if


### PR DESCRIPTION
Use a new environment variable 'ALTOOL_2FA_PASSWORD' dedicated to the Application Specific Password for the Application Loader tool in order to support 2 Factor Authentication (2FA) without side effect on other fastlane actions. Note that I gave the new variable priority over the default fastlane passwords ones.
Also update the README.md to document the new variable.